### PR TITLE
f-string mutation_args to avoid TypeErrors

### DIFF
--- a/graphqlmap/attacks.py
+++ b/graphqlmap/attacks.py
@@ -70,8 +70,8 @@ def dump_schema(url, method, graphversion, headers, use_json, proxy):
                         print("{} (\033[93m{}\033[0m!), ".format(args_name, args_ttype), end='')
                         cmdlist.append(args_name)
 
-                        # generate mutation query
-                        mutation_args += args_name + ":" + args_ttype + ","
+                        # generate mutation query as a formatted string to avoid the program crashing when args_ttype is None
+                        mutation_args += f'{args_name}:{args_ttype},'
                     print("")
 
                     if (types['name'].lower().strip() == "mutations"):


### PR DESCRIPTION
The try-catch block at line 62 allows args_ttype to be None. Line 74 was updated to an f-string to convert None to str(None) to prevent the program from crashing.

Recently ran into this issue when testing a development environment which caused a None type to appear. Changing to an f-string mitigated this issue and allowed for enumeration to continue.